### PR TITLE
Update codeclimate formatter to never show source

### DIFF
--- a/src/flake8_json_reporter/reporters.py
+++ b/src/flake8_json_reporter/reporters.py
@@ -159,7 +159,5 @@ class CodeClimateJSON(base.BaseFormatter):
         return string
 
     def show_source(self, violation):
-        """Codeclimate does not have a good place to show the source.
-        Return None instead.
-        """
+        """Codeclimate does not have a good place to show the source."""
         return None

--- a/src/flake8_json_reporter/reporters.py
+++ b/src/flake8_json_reporter/reporters.py
@@ -83,7 +83,7 @@ class CodeClimateJSON(base.BaseFormatter):
         if self.output_fd is None or self.options.tee:
             print(output, end=self.newline)
 
-    def write(self, line = None, source = None) -> None:
+    def write(self, line=None, source=None) -> None:
         """Override write for convenience."""
         self._write(line)
 
@@ -151,7 +151,7 @@ class CodeClimateJSON(base.BaseFormatter):
         """Format a violation."""
         formatted = json.dumps(self.dictionary_from(violation))
         if self.reported_errors_count > 0:
-            string = ", {}".format(formatted)
+            string = f", {formatted}"
         else:
             string = formatted
 

--- a/src/flake8_json_reporter/reporters.py
+++ b/src/flake8_json_reporter/reporters.py
@@ -159,5 +159,7 @@ class CodeClimateJSON(base.BaseFormatter):
         return string
 
     def show_source(self, violation):
-        """Codeclimate does not have a good place to show the source. Return None."""
+        """ Codeclimate does not have a good place to show the source. 
+        Return None instead.
+        """
         return None

--- a/src/flake8_json_reporter/reporters.py
+++ b/src/flake8_json_reporter/reporters.py
@@ -83,33 +83,33 @@ class CodeClimateJSON(base.BaseFormatter):
         if self.output_fd is None or self.options.tee:
             print(output, end=self.newline)
 
-    def write_line(self, line):
+    def write(self, line = None, source = None) -> None:
         """Override write for convenience."""
-        self.write(line, None)
+        self._write(line)
 
     def start(self):
         """Override the default to start printing JSON."""
         super().start()
-        self.write_line("{")
+        self.write("{")
         self.files_reported_count = 0
 
     def stop(self):
         """Override the default to finish printing JSON."""
-        self.write_line("}")
+        self.write("}")
 
     def beginning(self, filename):
         """We're starting a new file."""
         json_filename = json.dumps(filename)
         if self.files_reported_count > 0:
-            self.write_line(f", {json_filename}: [")
+            self.write(f", {json_filename}: [")
         else:
-            self.write_line(f"{json_filename}: [")
+            self.write(f"{json_filename}: [")
         self.reported_errors_count = 0
 
     def finished(self, filename):
         """We've finished processing a file."""
         self.files_reported_count += 1
-        self.write_line("]")
+        self.write("]")
 
     @staticmethod
     def _fingerprint(violation):
@@ -151,7 +151,13 @@ class CodeClimateJSON(base.BaseFormatter):
         """Format a violation."""
         formatted = json.dumps(self.dictionary_from(violation))
         if self.reported_errors_count > 0:
-            self.write_line(f", {formatted}")
+            string = ", {}".format(formatted)
         else:
-            self.write_line(formatted)
+            string = formatted
+
         self.reported_errors_count += 1
+        return string
+
+    def show_source(self, violation):
+        """Codeclimate does not have a good place to show the source. Return None."""
+        return None

--- a/src/flake8_json_reporter/reporters.py
+++ b/src/flake8_json_reporter/reporters.py
@@ -159,7 +159,7 @@ class CodeClimateJSON(base.BaseFormatter):
         return string
 
     def show_source(self, violation):
-        """ Codeclimate does not have a good place to show the source. 
+        """Codeclimate does not have a good place to show the source.
         Return None instead.
         """
         return None


### PR DESCRIPTION
The codeclimate formatter breaks if the show source option is activated. This option would previously insert the source line, where the error occured as raw text into the json. This leads to parsing errors, when reading the generated json output. With the proposed changes, the source line will never be inserted. 

Close #13 