### PR TITLE
Pretty-print JSON output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ jobs:
         - os: ubuntu-latest
           python: 3.9
           toxenv: pre-commit
+        - os: ubuntu-latest
+          python: 3.9
+          toxenv: py
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 Flake8-JSON
 ===========
 
-This is a plugin for Flake8 that will format the output as JSON. By default,
-the output is **not** pretty-printed. We would love to add that as a separate
-formatter option, though.
+This is a plugin for Flake8 that will format the output as JSON. The output of
+the default JSON formatter is not pretty-printed. If you'd like the output to
+be pretty-printed, use json-pretty instead.
 
 CodeClimate support is also offered through this plugin as of v20.12.0
 
@@ -22,6 +22,10 @@ Usage
 .. code-block:: bash
 
     flake8 --format=json ...
+
+.. code-block:: bash
+
+    flake8 --format=json-pretty ...
 
 .. code-block:: bash
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ where = src/
 [options.entry_points]
 flake8.report =
     json = flake8_json_reporter.reporters:DefaultJSON
+    json-pretty = flake8_json_reporter.reporters:FormattedJSON
     codeclimate = flake8_json_reporter.reporters:CodeClimateJSON
 
 [bdist_wheel]

--- a/tests/flake8_json_reporter_test.py
+++ b/tests/flake8_json_reporter_test.py
@@ -1,0 +1,121 @@
+from argparse import Namespace
+
+import pytest
+from flake8.violation import Violation
+
+from flake8_json_reporter.reporters import FormattedJSON
+
+
+@pytest.fixture
+def formatter():
+    """Return a ``FormattedJSON`` instance."""
+    options = Namespace(output_file=None, color=False, tee=False)
+    formatter = FormattedJSON(options)
+    return formatter
+
+
+@pytest.fixture
+def violation():
+    return Violation(
+        code="E222",
+        filename="main.py",
+        line_number=42,
+        column_number=4,
+        text="multiple spaces after operator",
+        physical_line="x =  1",
+    )
+
+
+def run(formatter, violations):
+    formatter.start()
+    for filename in violations:
+        formatter.beginning(filename)
+        for violation in violations[filename]:
+            formatter.format(violation)
+        formatter.finished(filename)
+    formatter.stop()
+
+
+def test_no_files(capsys, formatter):
+    run(formatter, {})
+    stdout, _ = capsys.readouterr()
+    assert stdout == "{}\n"
+
+
+def test_single_file_no_violations(capsys, formatter):
+    run(formatter, {"main.py": []})
+    stdout, _ = capsys.readouterr()
+    expected = """\
+{
+  "main.py": []
+}
+"""
+    assert stdout == expected
+
+
+def test_multiple_files_no_violations(capsys, formatter):
+    run(formatter, {"main.py": [], "__init__.py": []})
+    stdout, _ = capsys.readouterr()
+    expected = """\
+{
+  "main.py": [],
+  "__init__.py": []
+}
+"""
+    assert stdout == expected
+
+
+def test_single_file_single_violation(capsys, formatter, violation):
+    run(formatter, {"main.py": [violation]})
+    stdout, _ = capsys.readouterr()
+    expected = """\
+{
+  "main.py": [
+    {
+      "code": "E222",
+      "filename": "main.py",
+      "line_number": 42,
+      "column_number": 4,
+      "text": "multiple spaces after operator",
+      "physical_line": "x =  1"
+    }
+  ]
+}
+"""
+    assert stdout == expected
+
+
+def test_single_file_multiple_violations(capsys, formatter, violation):
+    run(formatter, {"main.py": [violation] * 3})
+    stdout, _ = capsys.readouterr()
+    expected = """\
+{
+  "main.py": [
+    {
+      "code": "E222",
+      "filename": "main.py",
+      "line_number": 42,
+      "column_number": 4,
+      "text": "multiple spaces after operator",
+      "physical_line": "x =  1"
+    },
+    {
+      "code": "E222",
+      "filename": "main.py",
+      "line_number": 42,
+      "column_number": 4,
+      "text": "multiple spaces after operator",
+      "physical_line": "x =  1"
+    },
+    {
+      "code": "E222",
+      "filename": "main.py",
+      "line_number": 42,
+      "column_number": 4,
+      "text": "multiple spaces after operator",
+      "physical_line": "x =  1"
+    }
+  ]
+}
+"""
+    assert stdout == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 minversion = 2.3.1
-envlist = flake8,pre-commit
+envlist = py,flake8,pre-commit
 
 [testenv]
 deps =
+    flake8
+    pytest
 commands =
-
-[testenv:venv]
-deps =
-    .
-commands = {posargs}
+    pytest tests {posargs}
 
 # Linters
 [testenv:flake8]


### PR DESCRIPTION
Adds a new `FormattedJSON` formatter which pretty-prints the JSON output.

Not sure if we want to add a separate entry point or keep it behind a flag when running `flake8 --format=json`?

With the `DefaultJSON`:
```json
{"./venv/lib/python3.11/site-packages/setuptools/discovery.py": [{"code": "E501", "filename": "./venv/lib/python3.11/site-packages/setuptools/discovery.py", "line_number": 120, "column_number": 80, "text": "line too long (85 > 79 characters)", "physical_line": "    def _find_iter(cls, where: _Path, exclude: _Filter, include: _Filter) -> StrIter:\n"}]}
```
With pretty printing:
```json
{
  "./venv/lib/python3.11/site-packages/setuptools/discovery.py": [
    {
      "code": "E501",
      "filename": "./venv/lib/python3.11/site-packages/setuptools/discovery.py",
      "line_number": 120,
      "column_number": 80,
      "text": "line too long (85 > 79 characters)",
      "physical_line": "    def _find_iter(cls, where: _Path, exclude: _Filter, include: _Filter) -> StrIter:\n"
    }
  ]
}
```